### PR TITLE
#25 Additional fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,4 @@ COPY --from=builder --chown=nextjs:nodejs /app/schema.prisma ./schema.prisma
 
 USER nextjs
 
-EXPOSE 3000
-
-ENV PORT=3000
-
 CMD ["npm", "start"]

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "NODE_ENV=production next start",
     "watch": "npx tsc --watch",
     "test": "dotenv -e .env.test -- jest",
     "migrate:dev": "dotenv -e .env.local -- npx prisma migrate dev",


### PR DESCRIPTION
## Summary
- Remove unnecessary EXPOSE and ENV PORT from Dockerfile as docker-compose handles port configuration
- Set NODE_ENV=production in npm start script for explicit production environment

## Test plan
- [x] Verify application starts correctly with docker-compose
- [x] Confirm NODE_ENV=production is properly set in production environment
- [x] Test that port configuration works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)