### PR TITLE
fix #24 Add migration version API

### DIFF
--- a/app/api/migration-version/route.ts
+++ b/app/api/migration-version/route.ts
@@ -1,0 +1,13 @@
+import { type NextRequest } from 'next/server'
+
+import { createApiRoute, withTransaction } from '@/lib/backend/api-transaction'
+import { getMigrationVersion } from '@/lib/backend/services/get-migration-version'
+
+async function handleGet(conn: any, { req: _ }: { req: NextRequest }) {
+  return withTransaction(conn, async (tx) => {
+    const result = await getMigrationVersion(tx)
+    return result
+  })
+}
+
+export const GET = createApiRoute(handleGet)

--- a/app/backup/page.tsx
+++ b/app/backup/page.tsx
@@ -1,10 +1,25 @@
-"use client"
+'use client'
 
-import { useState, useEffect } from "react"
-import { Calendar, Database, Download, Info, RotateCw, Upload } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
-import { toast } from "@/components/ui/use-toast"
+import { useEffect, useState } from 'react'
+
+import {
+  Calendar,
+  Database,
+  Download,
+  Info,
+  RotateCw,
+  Upload,
+} from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { toast } from '@/components/ui/use-toast'
 
 // バックアップ履歴の型定義
 interface BackupHistory {
@@ -18,34 +33,56 @@ export default function BackupPage() {
   // バックアップ状態
   const [isBackingUp, setIsBackingUp] = useState(false)
   const [isRestoring, setIsRestoring] = useState(false)
-  
-  // 現在適用中のマイグレーション（モック）
-  const currentMigration = "add_journals_table"
+
+  // 現在適用中のマイグレーション
+  const [currentMigration, setCurrentMigration] = useState<string>('取得中...')
+
+  // マイグレーションバージョンを取得
+  useEffect(() => {
+    const fetchMigrationVersion = async () => {
+      try {
+        const response = await fetch('/api/migration-version')
+        const data = await response.json()
+        console.log('Migration version API response:', data)
+
+        if (data.success) {
+          setCurrentMigration(data.data.migrationVersion)
+        } else {
+          setCurrentMigration('取得失敗')
+        }
+      } catch (error) {
+        console.error('Failed to fetch migration version:', error)
+        setCurrentMigration('取得エラー')
+      }
+    }
+
+    fetchMigrationVersion()
+  }, [])
 
   // モックデータ - バックアップ履歴
   const backupHistory: BackupHistory[] = [
     {
-      id: "20241228120000",
-      timestamp: "20241228120000",
-      migration: "add_journals_table",
+      id: '20241228120000',
+      timestamp: '20241228120000',
+      migration: 'add_journals_table',
       canRestore: true,
     },
     {
-      id: "20241227230000",
-      timestamp: "20241227230000",
-      migration: "add_consumption_tax_mappings",
+      id: '20241227230000',
+      timestamp: '20241227230000',
+      migration: 'add_consumption_tax_mappings',
       canRestore: true,
     },
     {
-      id: "20241220150000",
-      timestamp: "20241220150000",
-      migration: "add_account_masters",
+      id: '20241220150000',
+      timestamp: '20241220150000',
+      migration: 'add_account_masters',
       canRestore: false,
     },
     {
-      id: "20241215100000",
-      timestamp: "20241215100000",
-      migration: "create_initial_schema",
+      id: '20241215100000',
+      timestamp: '20241215100000',
+      migration: 'create_initial_schema',
       canRestore: false,
     },
   ]
@@ -57,14 +94,15 @@ export default function BackupPage() {
       // バックアップ処理のシミュレーション
       await new Promise((resolve) => setTimeout(resolve, 2000))
       toast({
-        title: "バックアップが完了しました",
-        description: `${new Date().toLocaleString("ja-JP")}にバックアップを作成しました。`,
+        title: 'バックアップが完了しました',
+        description: `${new Date().toLocaleString('ja-JP')}にバックアップを作成しました。`,
       })
     } catch (error) {
       toast({
-        title: "バックアップに失敗しました",
-        description: "バックアップ処理中にエラーが発生しました。もう一度お試しください。",
-        variant: "destructive",
+        title: 'バックアップに失敗しました',
+        description:
+          'バックアップ処理中にエラーが発生しました。もう一度お試しください。',
+        variant: 'destructive',
       })
     } finally {
       setIsBackingUp(false)
@@ -78,14 +116,15 @@ export default function BackupPage() {
       // 復元処理のシミュレーション
       await new Promise((resolve) => setTimeout(resolve, 2000))
       toast({
-        title: "復元が完了しました",
+        title: '復元が完了しました',
         description: `バックアップ ${formatTimestamp(backup.timestamp)} からデータを復元しました。`,
       })
     } catch (error) {
       toast({
-        title: "復元に失敗しました",
-        description: "復元処理中にエラーが発生しました。もう一度お試しください。",
-        variant: "destructive",
+        title: '復元に失敗しました',
+        description:
+          '復元処理中にエラーが発生しました。もう一度お試しください。',
+        variant: 'destructive',
       })
     } finally {
       setIsRestoring(false)
@@ -95,16 +134,15 @@ export default function BackupPage() {
   // タイムスタンプを表示用の日時に変換
   const formatTimestamp = (timestamp: string) => {
     if (!/^\d{14}$/.test(timestamp)) return timestamp
-    
+
     const year = timestamp.substring(0, 4)
     const month = timestamp.substring(4, 6)
     const day = timestamp.substring(6, 8)
     const hour = timestamp.substring(8, 10)
     const minute = timestamp.substring(10, 12)
-    
+
     return `${year}/${month}/${day} ${hour}:${minute}`
   }
-
 
   return (
     <div className="container mx-auto px-4 py-6">
@@ -116,7 +154,7 @@ export default function BackupPage() {
               バックアップ管理
             </h2>
             <div className="text-sm text-gray-600">
-              現在のマイグレーション: 
+              現在のマイグレーション:
               <code className="ml-2 bg-green-100 text-green-800 px-2 py-1 rounded text-xs">
                 {currentMigration}
               </code>
@@ -132,7 +170,9 @@ export default function BackupPage() {
                 <Download className="h-5 w-5 mr-2" />
                 手動バックアップ
               </CardTitle>
-              <CardDescription>現在のデータを手動でバックアップします</CardDescription>
+              <CardDescription>
+                現在のデータを手動でバックアップします
+              </CardDescription>
             </CardHeader>
             <CardContent>
               <div className="flex items-center justify-between">
@@ -141,7 +181,11 @@ export default function BackupPage() {
                     すべてのデータをクラウドストレージにバックアップします。処理には数分かかる場合があります。
                   </p>
                 </div>
-                <Button onClick={handleManualBackup} disabled={isBackingUp} className="ml-4">
+                <Button
+                  onClick={handleManualBackup}
+                  disabled={isBackingUp}
+                  className="ml-4"
+                >
                   {isBackingUp ? (
                     <>
                       <RotateCw className="mr-2 h-4 w-4 animate-spin" />
@@ -162,14 +206,17 @@ export default function BackupPage() {
           <Card>
             <CardHeader>
               <CardTitle>バックアップ履歴</CardTitle>
-              <CardDescription>過去のバックアップ記録を表示します</CardDescription>
+              <CardDescription>
+                過去のバックアップ記録を表示します
+              </CardDescription>
             </CardHeader>
             <CardContent className="pt-0">
               <div className="mb-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
                 <div className="flex items-start">
                   <Info className="h-4 w-4 text-yellow-600 mt-0.5 mr-2 flex-shrink-0" />
                   <div className="text-sm text-yellow-800">
-                    現在のマイグレーションと一致するバックアップのみ復元可能です。<br />
+                    現在のマイグレーションと一致するバックアップのみ復元可能です。
+                    <br />
                     異なるマイグレーションのバックアップを復元したい場合は、事前に対応するマイグレーションを実行してください。
                   </div>
                 </div>
@@ -199,19 +246,23 @@ export default function BackupPage() {
                         </td>
                         <td className="py-3 text-right">
                           <Button
-                            variant={backup.canRestore ? "outline" : "outline"}
+                            variant={backup.canRestore ? 'outline' : 'outline'}
                             size="sm"
                             className={`ml-2 ${!backup.canRestore ? 'opacity-50 cursor-not-allowed' : ''}`}
                             onClick={() => handleRestore(backup)}
                             disabled={isRestoring || !backup.canRestore}
-                            title={!backup.canRestore ? "マイグレーションが異なるため復元できません" : ""}
+                            title={
+                              !backup.canRestore
+                                ? 'マイグレーションが異なるため復元できません'
+                                : ''
+                            }
                           >
                             {isRestoring ? (
                               <RotateCw className="h-4 w-4 animate-spin" />
                             ) : (
                               <>
                                 <Upload className="h-4 w-4 mr-1" />
-                                {backup.canRestore ? "復元" : "復元不可"}
+                                {backup.canRestore ? '復元' : '復元不可'}
                               </>
                             )}
                           </Button>

--- a/lib/backend/services/get-migration-version.ts
+++ b/lib/backend/services/get-migration-version.ts
@@ -1,0 +1,19 @@
+import { Connection } from '@/lib/backend/api-transaction'
+
+export async function getMigrationVersion(conn: Connection) {
+  const result = await conn.$queryRaw<{ migration_name: string }[]>`
+    SELECT migration_name
+    FROM "_prisma_migrations"
+    WHERE finished_at IS NOT NULL
+    ORDER BY finished_at DESC
+    LIMIT 1
+  `
+
+  if (result.length === 0) {
+    throw new Error('No applied migrations found')
+  }
+
+  return {
+    migrationVersion: result[0].migration_name,
+  }
+}


### PR DESCRIPTION
## Summary
- Add API endpoint to retrieve current database migration version
- Integrate migration version display in backup page
- Fix unused parameter warnings

## Test plan
- [x] API endpoint returns current migration version from _prisma_migrations table
- [x] Backup page displays real migration version instead of mock data
- [x] Console logs API response for verification

🤖 Generated with [Claude Code](https://claude.ai/code)