### PR TITLE
Display detailed breakdown for payroll additions in payroll summary

### DIFF
--- a/app/payroll/page.tsx
+++ b/app/payroll/page.tsx
@@ -296,6 +296,19 @@ function PayrollTable({
                                       </span>
                                     </div>
                                   ))}
+                                  <div className="text-gray-400 text-[10px] mt-1">
+                                    (小計)
+                                  </div>
+                                  <div className="text-gray-400 text-[10px]">
+                                    <span className="font-mono text-xs">
+                                      {formatCurrency(
+                                        item.details.reduce(
+                                          (sum, detail) => sum + detail.amount,
+                                          0,
+                                        ),
+                                      )}
+                                    </span>
+                                  </div>
                                 </div>
                               </div>
                             )}

--- a/app/payroll/page.tsx
+++ b/app/payroll/page.tsx
@@ -270,14 +270,35 @@ function PayrollTable({
                       )}
                       <div className="space-y-1.5">
                         {summary.payroll_addition.map((item, index) => (
-                          <div
-                            key={index}
-                            className="text-gray-600 leading-relaxed text-xs"
-                          >
-                            <span className="font-medium">{item.name}:</span>{' '}
-                            <span className="font-mono">
-                              {formatCurrency(item.amount)}
-                            </span>
+                          <div key={index}>
+                            <div className="text-gray-600 leading-relaxed text-xs">
+                              <span className="font-medium">{item.name}:</span>{' '}
+                              <span className="font-mono">
+                                {formatCurrency(item.amount)}
+                              </span>
+                            </div>
+                            {item.details && item.details.length > 0 && (
+                              <div>
+                                <div className="text-gray-400 text-[10px] ml-2">
+                                  (明細)
+                                </div>
+                                <div className="ml-4 space-y-0.5">
+                                  {item.details.map((detail, detailIndex) => (
+                                    <div
+                                      key={detailIndex}
+                                      className="text-gray-400 text-[10px]"
+                                    >
+                                      <span className="font-medium">
+                                        {detail.name}:
+                                      </span>{' '}
+                                      <span className="font-mono text-xs">
+                                        {formatCurrency(detail.amount)}
+                                      </span>
+                                    </div>
+                                  ))}
+                                </div>
+                              </div>
+                            )}
                           </div>
                         ))}
                       </div>
@@ -290,7 +311,6 @@ function PayrollTable({
                   </TableCell>
                   <TableCell className="text-center py-4 align-top">
                     <PaymentStatusCell
-                      month={summary.monthNum}
                       isPaid={paymentStatuses[summary.monthNum] || false}
                       isLoading={loadingPayments[summary.monthNum] || false}
                       journalCheckStatus={
@@ -310,13 +330,11 @@ function PayrollTable({
 }
 
 function PaymentStatusCell({
-  month,
   isPaid,
   isLoading,
   journalCheckStatus,
   onMarkAsPaid,
 }: {
-  month: number
   isPaid: boolean
   isLoading: boolean
   journalCheckStatus?: {

--- a/lib/backend/services/reports/payroll-summary.ts
+++ b/lib/backend/services/reports/payroll-summary.ts
@@ -47,7 +47,7 @@ async function getExpenseAdvanceDetails(
              join saimoku_masters kasi_s on j.kasikata_cd = kasi_s.saimoku_cd
     where j.nendo = ${fiscalYear}
       and j.deleted = '0'
-      and j.kasikata_cd = 'B13'
+      and kasi_s.custom_fields ->> 'category' = 'payroll_addition'
       and substring(j.date, 1, 6) = ${month}
       and (kari_s.custom_fields ->> 'category' != 'fiscal_carryover' or kari_s.custom_fields ->> 'category' is null)
     group by j.karikata_cd, kari_s.saimoku_full_name

--- a/lib/backend/services/reports/payroll-summary.ts
+++ b/lib/backend/services/reports/payroll-summary.ts
@@ -4,6 +4,7 @@ interface PayrollItem {
   code: string
   name: string
   amount: number
+  details?: PayrollItem[]
 }
 
 interface PayrollSummary {
@@ -24,6 +25,39 @@ interface PayrollDetailRow {
   payroll_type: string
   kari_saimoku_name: string
   kasi_saimoku_name: string
+}
+
+async function getExpenseAdvanceDetails(
+  conn: Connection,
+  fiscalYear: string,
+  month: string,
+): Promise<PayrollItem[]> {
+  const expenseDetails = await conn.$queryRaw<
+    {
+      karikata_cd: string
+      kari_saimoku_name: string
+      amount: number
+    }[]
+  >`
+    select j.karikata_cd,
+           kari_s.saimoku_full_name as kari_saimoku_name,
+           sum(j.karikata_value) as amount
+    from journals j
+             join saimoku_masters kari_s on j.karikata_cd = kari_s.saimoku_cd
+             join saimoku_masters kasi_s on j.kasikata_cd = kasi_s.saimoku_cd
+    where j.nendo = ${fiscalYear}
+      and j.deleted = '0'
+      and j.kasikata_cd = 'B13'
+      and substring(j.date, 1, 6) = ${month}
+      and (kari_s.custom_fields ->> 'category' != 'fiscal_carryover' or kari_s.custom_fields ->> 'category' is null)
+    group by j.karikata_cd, kari_s.saimoku_full_name
+    order by j.karikata_cd`
+
+  return expenseDetails.map((detail) => ({
+    code: detail.karikata_cd,
+    name: detail.kari_saimoku_name,
+    amount: Number(detail.amount),
+  }))
 }
 
 export async function getPayrollSummary(
@@ -100,14 +134,14 @@ export async function getPayrollSummary(
     for (const row of rows) {
       const kariCustomFields = JSON.parse(row.kari_custom_fields || '{}')
       const isFiscalCarryover = kariCustomFields.category === 'fiscal_carryover'
-      
+
       if (isFiscalCarryover) {
         continue
       }
 
       if (row.payroll_type === 'payroll_base') {
         const kariCustomFields = JSON.parse(row.kari_custom_fields || '{}')
-        
+
         // 年末調整の場合（借方がpayroll_deduction、貸方がpayroll_base）
         if (kariCustomFields.category === 'payroll_deduction') {
           // 年末調整還付分として加算項目に分類
@@ -160,10 +194,30 @@ export async function getPayrollSummary(
     result.push({
       month,
       payroll_base,
-      payroll_deduction: Array.from(deductionMap.values()).sort((a, b) => a.code.localeCompare(b.code)),
-      payroll_addition: Array.from(additionMap.values()).sort((a, b) => a.code.localeCompare(b.code)),
+      payroll_deduction: Array.from(deductionMap.values()).sort((a, b) =>
+        a.code.localeCompare(b.code),
+      ),
+      payroll_addition: Array.from(additionMap.values()).sort((a, b) =>
+        a.code.localeCompare(b.code),
+      ),
       net_payment,
     })
+  }
+
+  // 立替金の詳細を取得して追加
+  for (const summary of result) {
+    for (const additionItem of summary.payroll_addition) {
+      if (additionItem.code === 'B13') {
+        const expenseDetails = await getExpenseAdvanceDetails(
+          conn,
+          fiscalYear,
+          summary.month,
+        )
+        if (expenseDetails.length > 0) {
+          additionItem.details = expenseDetails
+        }
+      }
+    }
   }
 
   return result.sort((a, b) => a.month.localeCompare(b.month))

--- a/lib/redux/features/payrollSlice.ts
+++ b/lib/redux/features/payrollSlice.ts
@@ -6,6 +6,7 @@ export interface PayrollItem {
   code: string
   name: string
   amount: number
+  details?: PayrollItem[]
 }
 
 export interface PayrollSummary {
@@ -32,12 +33,14 @@ export const fetchPayrollSummary = createAsyncThunk<
   PayrollSummary[] | { data: PayrollSummary[] },
   string
 >('payroll/fetchPayrollSummary', async (fiscalYear: string) => {
-  const response = await fetch(`/api/fiscal-years/${fiscalYear}/reports/payroll-summary`)
-  
+  const response = await fetch(
+    `/api/fiscal-years/${fiscalYear}/reports/payroll-summary`,
+  )
+
   if (!response.ok) {
     throw new Error('給与データの取得に失敗しました')
   }
-  
+
   return response.json()
 })
 
@@ -59,7 +62,9 @@ export const payrollSlice = createSlice({
       })
       .addCase(fetchPayrollSummary.fulfilled, (state, action) => {
         state.loading = false
-        state.summaries = Array.isArray(action.payload) ? action.payload : (action.payload as { data: PayrollSummary[] }).data || []
+        state.summaries = Array.isArray(action.payload)
+          ? action.payload
+          : (action.payload as { data: PayrollSummary[] }).data || []
       })
       .addCase(fetchPayrollSummary.rejected, (state, action) => {
         state.loading = false


### PR DESCRIPTION
## Summary
- Add detailed breakdown display for payroll additions (立替金) in payroll summary table
- Show itemized expense categories (地代家賃, 旅費交通費, etc.) under expense advances
- Add subtotal calculation to validate consistency between main total and detail sum

## Changes Made
- **Backend**: Add `getExpenseAdvanceDetails` function to fetch expense breakdown by category
- **Data Model**: Extend `PayrollItem` interface with optional `details` array
- **Frontend**: Display expense details with proper indentation and styling
- **Validation**: Add subtotal row to compare main total vs detail sum

## Implementation Details
- Use `custom_fields` category filtering instead of hardcoded account codes
- Exclude fiscal carryover transactions from detail calculations
- Display format: Main item → (明細) label → Detail items → (小計) → Subtotal amount

fix #73